### PR TITLE
switched numpy's array_equal with allclose routine

### DIFF
--- a/src/ssc_course_team4/tests/test_numerical.py
+++ b/src/ssc_course_team4/tests/test_numerical.py
@@ -31,8 +31,10 @@ def test_efield_fft():
     test_data, test_freq = nm.efield_fft(test_df, 1e-5)
 
     # compare arrays
-    assert np.array_equal(test_data, ref_data)
-    assert np.array_equal(test_freq, ref_freq)
+    # assert np.array_equal(test_data, ref_data)
+    assert np.allclose(test_data, ref_data, atol=1e-08)
+    # assert np.array_equal(test_freq, ref_freq)
+    assert np.allclose(test_freq, ref_freq, atol=1e-08)
 
 
 def time_arr(time_dim):


### PR DESCRIPTION
Yesterday I had failed to notice that the numbers that were being compared are almost zero (~E-16). It is actually quite normal that you will get different results for numbers that small on different operating systems/different environments, due to numerical accuracy. So if you compare to pre-computed values in your tests, then it is better to account for a tolerance, which in numpy you can do through the np.allclose() routine (instead of np.array_equal). I included this in the test_numerical module, it is possible that you also need this for the Euclidean distance in test_statistical.